### PR TITLE
refactor: introduce MVVM + provider architecture with network/upload flow

### DIFF
--- a/risk_eye_mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/risk_eye_mobile_app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <application
         android:label="risk_eye_mobile_app"
         android:name="${applicationName}"

--- a/risk_eye_mobile_app/ios/Runner/Info.plist
+++ b/risk_eye_mobile_app/ios/Runner/Info.plist
@@ -43,7 +43,11 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSCameraUsageDescription</key>
+        <string>This app requires camera access to take photos of documents.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>This app requires photo library access to select images for upload.</string>
 </dict>
 </plist>

--- a/risk_eye_mobile_app/lib/core/config/app_config.dart
+++ b/risk_eye_mobile_app/lib/core/config/app_config.dart
@@ -1,0 +1,3 @@
+class AppConfig {
+  static const String baseUrl = 'https://api.example.com';
+}

--- a/risk_eye_mobile_app/lib/core/error/app_exception.dart
+++ b/risk_eye_mobile_app/lib/core/error/app_exception.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart';
+
+enum AppErrorType { network, timeout, response, unknown }
+
+class AppException implements Exception {
+  final String message;
+  final AppErrorType type;
+  final int? code;
+
+  AppException(this.message, {this.type = AppErrorType.unknown, this.code});
+
+  factory AppException.fromDio(DioException error) {
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.sendTimeout:
+        return AppException('请求超时', type: AppErrorType.timeout);
+      case DioExceptionType.badResponse:
+        return AppException('服务器错误',
+            type: AppErrorType.response, code: error.response?.statusCode);
+      case DioExceptionType.connectionError:
+      case DioExceptionType.unknown:
+        return AppException('网络异常', type: AppErrorType.network);
+      case DioExceptionType.cancel:
+        return AppException('请求取消');
+      default:
+        return AppException(error.message ?? '未知错误');
+    }
+  }
+
+  @override
+  String toString() => message;
+}

--- a/risk_eye_mobile_app/lib/core/network/dio_client.dart
+++ b/risk_eye_mobile_app/lib/core/network/dio_client.dart
@@ -1,0 +1,31 @@
+import 'package:dio/dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../config/app_config.dart';
+import 'interceptors.dart';
+
+/// Provides a configured [Dio] client.
+class DioClient {
+  final Dio _dio;
+
+  DioClient._(this._dio);
+
+  factory DioClient(SharedPreferences prefs) {
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: AppConfig.baseUrl,
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ),
+    );
+    dio.interceptors.addAll([
+      TokenInterceptor(prefs),
+      ErrorInterceptor(),
+      // LogInterceptor(), // enable to log network
+    ]);
+    // TODO: add retry interceptor if needed
+    return DioClient._(dio);
+  }
+
+  Dio get client => _dio;
+}

--- a/risk_eye_mobile_app/lib/core/network/interceptors.dart
+++ b/risk_eye_mobile_app/lib/core/network/interceptors.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../error/app_exception.dart';
+
+/// Injects auth token stored in [SharedPreferences].
+class TokenInterceptor extends Interceptor {
+  final SharedPreferences prefs;
+  TokenInterceptor(this.prefs);
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    final token = prefs.getString('auth_token');
+    if (token != null) {
+      options.headers['Authorization'] = 'Bearer $token';
+    }
+    handler.next(options);
+  }
+}
+
+/// Normalizes [DioException] into [AppException].
+class ErrorInterceptor extends Interceptor {
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    err.error = AppException.fromDio(err);
+    handler.next(err);
+  }
+}

--- a/risk_eye_mobile_app/lib/features/score/score_page.dart
+++ b/risk_eye_mobile_app/lib/features/score/score_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../../viewmodels/loan_view_model.dart';
+
+class ScorePage extends StatelessWidget {
+  const ScorePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = context.watch<LoanViewModel>();
+    final score = vm.score;
+    return Scaffold(
+      appBar: AppBar(title: const Text('评分结果')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: () => context
+                      .read<LoanViewModel>()
+                      .fetchLatestScore('user123'),
+                  child: const Text('获取最近评分'),
+                ),
+                const SizedBox(width: 16),
+                ElevatedButton(
+                  onPressed: () => context
+                      .read<LoanViewModel>()
+                      .triggerScore('user123'),
+                  child: const Text('触发评分'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            if (vm.loading) const Center(child: CircularProgressIndicator()),
+            if (score != null) ...[
+              Text('Score: ${score.score}'),
+              Text('Decision: ${score.decision.name}'),
+              Text('ModelVersion: ${score.modelVersion}'),
+              Text('ReasonCodes: ${score.reasonCodes.join(', ')}'),
+              Text('Time: ${DateFormat.yMd().add_jm().format(score.createdAt)}'),
+            ],
+            if (vm.error != null)
+              Text(vm.error!, style: const TextStyle(color: Colors.red)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/risk_eye_mobile_app/lib/features/upload/upload_page.dart
+++ b/risk_eye_mobile_app/lib/features/upload/upload_page.dart
@@ -1,36 +1,45 @@
 import 'package:flutter/material.dart';
-import '../../widgets/app_bar.dart';
-import '../../widgets/uploader_tile.dart';
-import '../../widgets/buttons.dart';
-import '../evaluating/evaluating_page.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+
+import '../../viewmodels/upload_view_model.dart';
 
 class UploadPage extends StatelessWidget {
   const UploadPage({super.key});
 
-  static const String routeName = '/upload';
-
   @override
   Widget build(BuildContext context) {
+    final vm = context.watch<UploadViewModel>();
     return Scaffold(
-      appBar: const RiskAppBar(title: '上传资料'),
-      body: GridView.count(
+      appBar: AppBar(title: const Text('上传资料')),
+      body: Padding(
         padding: const EdgeInsets.all(16),
-        crossAxisCount: 2,
-        childAspectRatio: 1.2,
-        children: const [
-          UploaderTile(icon: Icons.credit_card, title: '身份证', status: '未上传'),
-          UploaderTile(icon: Icons.account_balance, title: '银行流水', status: '未上传'),
-          UploaderTile(icon: Icons.home, title: '房产证', status: '未上传'),
-          UploaderTile(icon: Icons.insert_drive_file, title: '其他证明', status: '未上传'),
-        ],
-      ),
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.all(16),
-        child: PrimaryButton(
-          label: '开始风险评估',
-          onPressed: () {
-            Navigator.pushNamed(context, EvaluatingPage.routeName);
-          },
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
+                  onPressed: () => context
+                      .read<UploadViewModel>()
+                      .pickAndUpload(ImageSource.camera, type: 'id'),
+                  child: const Text('拍照上传'),
+                ),
+                ElevatedButton(
+                  onPressed: () => context
+                      .read<UploadViewModel>()
+                      .pickAndUpload(ImageSource.gallery, type: 'id'),
+                  child: const Text('相册选择上传'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            if (vm.uploading) LinearProgressIndicator(value: vm.progress),
+            if (vm.result != null) Text('上传成功: ${vm.result!.url}'),
+            if (vm.error != null)
+              Text(vm.error!, style: const TextStyle(color: Colors.red)),
+          ],
         ),
       ),
     );

--- a/risk_eye_mobile_app/lib/main.dart
+++ b/risk_eye_mobile_app/lib/main.dart
@@ -1,6 +1,68 @@
 import 'package:flutter/material.dart';
-import 'app.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
-  runApp(const MyApp());
+import 'core/network/dio_client.dart';
+import 'repositories/loan_repository.dart';
+import 'repositories/upload_repository.dart';
+import 'viewmodels/loan_view_model.dart';
+import 'viewmodels/upload_view_model.dart';
+import 'features/score/score_page.dart';
+import 'features/upload/upload_page.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  final dio = DioClient(prefs);
+  runApp(MyApp(dio));
+}
+
+class MyApp extends StatelessWidget {
+  final DioClient dio;
+  const MyApp(this.dio, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+            create: (_) => LoanViewModel(LoanRepository(dio))),
+        ChangeNotifierProvider(
+            create: (_) => UploadViewModel(UploadRepository(dio))),
+      ],
+      child: const MaterialApp(
+        title: 'Risk Eye',
+        home: _HomePage(),
+      ),
+    );
+  }
+}
+
+class _HomePage extends StatefulWidget {
+  const _HomePage();
+
+  @override
+  State<_HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<_HomePage> {
+  int index = 0;
+  final pages = const [ScorePage(), UploadPage()];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: pages[index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: index,
+        onTap: (i) => setState(() => index = i),
+        items: const [
+          BottomNavigationBarItem(
+              icon: Icon(Icons.assessment), label: '评分'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.cloud_upload), label: '上传'),
+        ],
+      ),
+    );
+  }
 }

--- a/risk_eye_mobile_app/lib/models/loan_score.dart
+++ b/risk_eye_mobile_app/lib/models/loan_score.dart
@@ -1,0 +1,27 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'loan_score.g.dart';
+
+enum Decision { approve, review, reject }
+
+@JsonSerializable()
+class LoanScore {
+  final double score;
+  final Decision decision;
+  final String modelVersion;
+  final List<String> reasonCodes;
+  @JsonKey(name: 'created_at')
+  final DateTime createdAt;
+
+  LoanScore({
+    required this.score,
+    required this.decision,
+    required this.modelVersion,
+    required this.reasonCodes,
+    required this.createdAt,
+  });
+
+  factory LoanScore.fromJson(Map<String, dynamic> json) =>
+      _$LoanScoreFromJson(json);
+  Map<String, dynamic> toJson() => _$LoanScoreToJson(this);
+}

--- a/risk_eye_mobile_app/lib/models/loan_score.g.dart
+++ b/risk_eye_mobile_app/lib/models/loan_score.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'loan_score.dart';
+
+LoanScore _$LoanScoreFromJson(Map<String, dynamic> json) => LoanScore(
+      score: (json['score'] as num).toDouble(),
+      decision: $enumDecode(_$DecisionEnumMap, json['decision']),
+      modelVersion: json['modelVersion'] as String,
+      reasonCodes:
+          (json['reasonCodes'] as List<dynamic>).map((e) => e as String).toList(),
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$LoanScoreToJson(LoanScore instance) => <String, dynamic>{
+      'score': instance.score,
+      'decision': _$DecisionEnumMap[instance.decision]!,
+      'modelVersion': instance.modelVersion,
+      'reasonCodes': instance.reasonCodes,
+      'created_at': instance.createdAt.toIso8601String(),
+    };
+
+const Map<Decision, String> _$DecisionEnumMap = {
+  Decision.approve: 'approve',
+  Decision.review: 'review',
+  Decision.reject: 'reject',
+};
+

--- a/risk_eye_mobile_app/lib/models/upload_result.dart
+++ b/risk_eye_mobile_app/lib/models/upload_result.dart
@@ -1,0 +1,21 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'upload_result.g.dart';
+
+@JsonSerializable()
+class UploadResult {
+  final String id;
+  final String url;
+  @JsonKey(name: 'uploaded_at')
+  final DateTime uploadedAt;
+
+  UploadResult({
+    required this.id,
+    required this.url,
+    required this.uploadedAt,
+  });
+
+  factory UploadResult.fromJson(Map<String, dynamic> json) =>
+      _$UploadResultFromJson(json);
+  Map<String, dynamic> toJson() => _$UploadResultToJson(this);
+}

--- a/risk_eye_mobile_app/lib/models/upload_result.g.dart
+++ b/risk_eye_mobile_app/lib/models/upload_result.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'upload_result.dart';
+
+UploadResult _$UploadResultFromJson(Map<String, dynamic> json) => UploadResult(
+      id: json['id'] as String,
+      url: json['url'] as String,
+      uploadedAt: DateTime.parse(json['uploaded_at'] as String),
+    );
+
+Map<String, dynamic> _$UploadResultToJson(UploadResult instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'url': instance.url,
+      'uploaded_at': instance.uploadedAt.toIso8601String(),
+    };
+

--- a/risk_eye_mobile_app/lib/repositories/loan_repository.dart
+++ b/risk_eye_mobile_app/lib/repositories/loan_repository.dart
@@ -1,0 +1,30 @@
+import 'package:dio/dio.dart';
+
+import '../core/network/dio_client.dart';
+import '../models/loan_score.dart';
+import '../core/error/app_exception.dart';
+
+class LoanRepository {
+  final DioClient _client;
+  LoanRepository(this._client);
+
+  Future<LoanScore> getLatestScore(String userId) async {
+    try {
+      final res = await _client.client
+          .get('/loan/score/latest', queryParameters: {'userId': userId});
+      return LoanScore.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw e.error is AppException ? e.error : AppException.fromDio(e);
+    }
+  }
+
+  Future<LoanScore> triggerScore(String userId) async {
+    try {
+      final res = await _client.client
+          .post('/loan/score/trigger', data: {'userId': userId});
+      return LoanScore.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw e.error is AppException ? e.error : AppException.fromDio(e);
+    }
+  }
+}

--- a/risk_eye_mobile_app/lib/repositories/upload_repository.dart
+++ b/risk_eye_mobile_app/lib/repositories/upload_repository.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
+
+import '../core/network/dio_client.dart';
+import '../core/error/app_exception.dart';
+import '../models/upload_result.dart';
+
+class UploadRepository {
+  final DioClient _client;
+  UploadRepository(this._client);
+
+  Future<UploadResult> uploadDocument(
+    File file, {
+    required String type,
+    ProgressCallback? onSendProgress,
+  }) async {
+    File uploadFile = file;
+    if (file.lengthSync() > 1024 * 1024) {
+      final targetPath = '${file.path}_compressed.jpg';
+      final compressed = await FlutterImageCompress.compressAndGetFile(
+        file.absolute.path,
+        targetPath,
+        quality: 80,
+      );
+      if (compressed != null) {
+        uploadFile = compressed;
+      }
+    }
+
+    final formData = FormData.fromMap({
+      'type': type,
+      'file': await MultipartFile.fromFile(uploadFile.path),
+    });
+
+    try {
+      final res = await _client.client.post(
+        '/upload',
+        data: formData,
+        onSendProgress: onSendProgress,
+      );
+      return UploadResult.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      throw e.error is AppException ? e.error : AppException.fromDio(e);
+    }
+  }
+}

--- a/risk_eye_mobile_app/lib/viewmodels/loan_view_model.dart
+++ b/risk_eye_mobile_app/lib/viewmodels/loan_view_model.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+import '../core/error/app_exception.dart';
+import '../models/loan_score.dart';
+import '../repositories/loan_repository.dart';
+
+class LoanViewModel extends ChangeNotifier {
+  final LoanRepository repository;
+
+  bool loading = false;
+  LoanScore? score;
+  String? error;
+
+  LoanViewModel(this.repository);
+
+  Future<void> fetchLatestScore(String userId) async {
+    loading = true;
+    notifyListeners();
+    try {
+      score = await repository.getLatestScore(userId);
+      error = null;
+    } catch (e) {
+      error = _mapError(e);
+      Fluttertoast.showToast(msg: error!);
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> triggerScore(String userId) async {
+    loading = true;
+    notifyListeners();
+    try {
+      score = await repository.triggerScore(userId);
+      error = null;
+      Fluttertoast.showToast(msg: '评分成功');
+    } catch (e) {
+      error = _mapError(e);
+      Fluttertoast.showToast(msg: error!);
+    } finally {
+      loading = false;
+      notifyListeners();
+    }
+  }
+
+  String _mapError(Object e) {
+    if (e is AppException) {
+      return e.message;
+    }
+    return '未知错误';
+  }
+}

--- a/risk_eye_mobile_app/lib/viewmodels/upload_view_model.dart
+++ b/risk_eye_mobile_app/lib/viewmodels/upload_view_model.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+
+import '../core/error/app_exception.dart';
+import '../models/upload_result.dart';
+import '../repositories/upload_repository.dart';
+
+class UploadViewModel extends ChangeNotifier {
+  final UploadRepository repository;
+  final ImagePicker _picker = ImagePicker();
+
+  bool uploading = false;
+  double progress = 0;
+  UploadResult? result;
+  String? error;
+
+  UploadViewModel(this.repository);
+
+  Future<void> pickAndUpload(ImageSource source, {required String type}) async {
+    try {
+      final XFile? picked = await _picker.pickImage(source: source);
+      if (picked == null) {
+        Fluttertoast.showToast(msg: '未选择图片');
+        return;
+      }
+      uploading = true;
+      progress = 0;
+      notifyListeners();
+
+      final file = File(picked.path);
+      result = await repository.uploadDocument(
+        file,
+        type: type,
+        onSendProgress: (sent, total) {
+          progress = total == 0 ? 0 : sent / total;
+          notifyListeners();
+        },
+      );
+      error = null;
+      Fluttertoast.showToast(msg: '上传成功');
+    } on AppException catch (e) {
+      error = e.message;
+      Fluttertoast.showToast(msg: e.message);
+    } catch (e) {
+      error = e.toString();
+      Fluttertoast.showToast(msg: error!);
+    } finally {
+      uploading = false;
+      notifyListeners();
+    }
+  }
+}

--- a/risk_eye_mobile_app/pubspec.yaml
+++ b/risk_eye_mobile_app/pubspec.yaml
@@ -34,6 +34,14 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  dio: ^5.4.0
+  image_picker: ^1.1.2
+  flutter_image_compress: ^2.1.0
+  provider: ^6.0.5
+  shared_preferences: ^2.3.0
+  intl: ^0.19.0
+  fluttertoast: ^8.2.5
+  json_annotation: ^4.8.1
 
 dev_dependencies:
   flutter_test:
@@ -45,6 +53,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.7
+  json_serializable: ^6.7.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- restructure Flutter app with MVVM layers (ViewModels, Repositories, Network)
- add Dio client, interceptors, models and repositories for loan scoring and uploads
- implement provider-based Score and Upload pages with image picker and progress
- add required dependencies and platform permissions

## Testing
- `flutter pub get` (fails: command not found)
- `dart run build_runner build --delete-conflicting-outputs` (fails: command not found)
- `flutter format .` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a9e68f4b94832bbd7de10a9bffee9f