### PR TITLE
Fix interceptor error handling and add upload route

### DIFF
--- a/risk_eye_mobile_app/lib/core/network/interceptors.dart
+++ b/risk_eye_mobile_app/lib/core/network/interceptors.dart
@@ -22,7 +22,6 @@ class TokenInterceptor extends Interceptor {
 class ErrorInterceptor extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
-    err.error = AppException.fromDio(err);
-    handler.next(err);
+    handler.next(err.copyWith(error: AppException.fromDio(err)));
   }
 }

--- a/risk_eye_mobile_app/lib/features/upload/upload_page.dart
+++ b/risk_eye_mobile_app/lib/features/upload/upload_page.dart
@@ -7,6 +7,8 @@ import '../../viewmodels/upload_view_model.dart';
 class UploadPage extends StatelessWidget {
   const UploadPage({super.key});
 
+  static const routeName = '/upload';
+
   @override
   Widget build(BuildContext context) {
     final vm = context.watch<UploadViewModel>();

--- a/risk_eye_mobile_app/lib/repositories/loan_repository.dart
+++ b/risk_eye_mobile_app/lib/repositories/loan_repository.dart
@@ -14,7 +14,9 @@ class LoanRepository {
           .get('/loan/score/latest', queryParameters: {'userId': userId});
       return LoanScore.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
-      throw e.error is AppException ? e.error : AppException.fromDio(e);
+      throw e.error is AppException
+          ? e.error as AppException
+          : AppException.fromDio(e);
     }
   }
 
@@ -24,7 +26,9 @@ class LoanRepository {
           .post('/loan/score/trigger', data: {'userId': userId});
       return LoanScore.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
-      throw e.error is AppException ? e.error : AppException.fromDio(e);
+      throw e.error is AppException
+          ? e.error as AppException
+          : AppException.fromDio(e);
     }
   }
 }

--- a/risk_eye_mobile_app/lib/repositories/upload_repository.dart
+++ b/risk_eye_mobile_app/lib/repositories/upload_repository.dart
@@ -42,7 +42,9 @@ class UploadRepository {
       );
       return UploadResult.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
-      throw e.error is AppException ? e.error : AppException.fromDio(e);
+      throw e.error is AppException
+          ? e.error as AppException
+          : AppException.fromDio(e);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Refactor network ErrorInterceptor to copy DioException with AppException
- Add static route name to UploadPage for navigation
- Cast Dio error payloads to AppException before rethrowing

## Testing
- `flutter format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e8cbb67c832bb50ab939c064b178