### PR TITLE
feat: enhance home page and add analytics

### DIFF
--- a/risk_eye_mobile_app/lib/features/evaluating/evaluating_page.dart
+++ b/risk_eye_mobile_app/lib/features/evaluating/evaluating_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../widgets/app_bar.dart';
+import '../../services/analytics_service.dart';
+import '../../state/providers.dart';
 import '../result/result_page.dart';
 
 class EvaluatingPage extends StatefulWidget {
@@ -15,7 +17,10 @@ class _EvaluatingPageState extends State<EvaluatingPage> {
   @override
   void initState() {
     super.initState();
-    Future.delayed(const Duration(seconds: 2), () {
+    AnalyticsService.logEvent('evaluate_start');
+    Future.delayed(const Duration(seconds: 2), () async {
+      await appState.startEvaluation();
+      AnalyticsService.logEvent('evaluate_done');
       if (mounted) {
         Navigator.pushReplacementNamed(context, ResultPage.routeName);
       }

--- a/risk_eye_mobile_app/lib/features/home/home_page.dart
+++ b/risk_eye_mobile_app/lib/features/home/home_page.dart
@@ -1,43 +1,119 @@
 import 'package:flutter/material.dart';
 import '../../widgets/app_bar.dart';
-import '../../widgets/buttons.dart';
 import '../../widgets/cards.dart';
+import '../../services/analytics_service.dart';
+import '../../state/providers.dart';
 import '../upload/upload_page.dart';
+import '../evaluating/evaluating_page.dart';
+import '../settings/settings_page.dart';
+import '../result/result_page.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
 
   @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  @override
+  void initState() {
+    super.initState();
+    AnalyticsService.logEvent('home_view');
+    appState.addListener(_onStateChanged);
+    appState.loadHistory();
+  }
+
+  void _onStateChanged() => setState(() {});
+
+  @override
+  void dispose() {
+    appState.removeListener(_onStateChanged);
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final hasHistory = appState.history.isNotEmpty;
     return Scaffold(
-      appBar: const RiskAppBar(title: '首页'),
-      body: Padding(
+      appBar: RiskAppBar(
+        title: '首页',
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            onPressed: () {},
+          ),
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SettingsPage()),
+              );
+            },
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text('智能贷款风险评估工具'),
-            const SizedBox(height: 16),
-            PrimaryButton(
-              label: '上传资料',
-              onPressed: () {
-                Navigator.pushNamed(context, UploadPage.routeName);
-              },
+            Text(
+              '智能贷款风险评估工具',
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
-            const SizedBox(height: 24),
-            const Text('最近评估'),
-            const SizedBox(height: 8),
-            Expanded(
-              child: ListView(
-                children: const [
-                  ListItemCard(
-                    icon: Icons.credit_score,
-                    title: '示例评估',
-                    subtitle: '得分 720',
-                  ),
-                ],
+            const SizedBox(height: 4),
+            const Text('本地处理 · 隐私优先 · 秒级出分'),
+            const SizedBox(height: 16),
+            Card(
+              child: ListTile(
+                leading: const Icon(Icons.file_upload),
+                title: const Text('上传资料开始评估'),
+                subtitle: const Text('支持身份证、银行流水、房产等'),
+                onTap: () {
+                  AnalyticsService.logEvent('home_click_upload');
+                  Navigator.pushNamed(context, UploadPage.routeName);
+                },
               ),
             ),
+            const SizedBox(height: 12),
+            OutlinedButton(
+              onPressed: hasHistory
+                  ? () {
+                      AnalyticsService.logEvent('home_click_quick_eval');
+                      Navigator.pushNamed(context, EvaluatingPage.routeName);
+                    }
+                  : null,
+              child: const Text('使用上次资料评估'),
+            ),
+            const SizedBox(height: 24),
+            Text('最近评估', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (hasHistory)
+              ...appState.history.reversed.map((item) {
+                final date =
+                    item.createdAt.toLocal().toString().split('.').first;
+                return ListItemCard(
+                  icon: Icons.credit_score,
+                  title: date,
+                  subtitle: '分数 ${item.score} · ${item.decision}',
+                  onTap: () {
+                    AnalyticsService.logEvent('history_card_open');
+                    Navigator.pushNamed(context, ResultPage.routeName);
+                  },
+                );
+              })
+            else
+              ListItemCard(
+                icon: Icons.credit_score,
+                title: '示例评估',
+                subtitle: '得分 720',
+                onTap: () {
+                  AnalyticsService.logEvent('history_card_open');
+                  Navigator.pushNamed(context, ResultPage.routeName);
+                },
+              ),
           ],
         ),
       ),

--- a/risk_eye_mobile_app/lib/services/analytics_service.dart
+++ b/risk_eye_mobile_app/lib/services/analytics_service.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/foundation.dart';
+
+/// Simple analytics service that logs events to console.
+class AnalyticsService {
+  AnalyticsService._();
+
+  static void logEvent(String name) {
+    debugPrint('analytics_event: ' + name);
+  }
+}

--- a/risk_eye_mobile_app/lib/viewmodels/upload_view_model.dart
+++ b/risk_eye_mobile_app/lib/viewmodels/upload_view_model.dart
@@ -7,6 +7,7 @@ import 'package:fluttertoast/fluttertoast.dart';
 import '../core/error/app_exception.dart';
 import '../models/upload_result.dart';
 import '../repositories/upload_repository.dart';
+import '../services/analytics_service.dart';
 
 class UploadViewModel extends ChangeNotifier {
   final UploadRepository repository;
@@ -41,12 +42,15 @@ class UploadViewModel extends ChangeNotifier {
       );
       error = null;
       Fluttertoast.showToast(msg: '上传成功');
+      AnalyticsService.logEvent('upload_success');
     } on AppException catch (e) {
       error = e.message;
       Fluttertoast.showToast(msg: e.message);
+      AnalyticsService.logEvent('error_upload_fail');
     } catch (e) {
       error = e.toString();
       Fluttertoast.showToast(msg: error!);
+      AnalyticsService.logEvent('error_upload_fail');
     } finally {
       uploading = false;
       notifyListeners();


### PR DESCRIPTION
## Summary
- enrich home screen with hero text, upload card, and quick evaluation button gated on history
- add lightweight analytics service and log events from home, upload, and evaluation flows

## Testing
- `flutter format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ed04aecc832b9049c9de3ce82af4