### PR TITLE
feat: enhance result page with dynamic data

### DIFF
--- a/risk_eye_mobile_app/lib/features/history/history_page.dart
+++ b/risk_eye_mobile_app/lib/features/history/history_page.dart
@@ -6,6 +6,8 @@ import '../result/result_page.dart';
 class HistoryPage extends StatelessWidget {
   const HistoryPage({super.key});
 
+  static const String routeName = '/history';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/risk_eye_mobile_app/lib/features/result/result_page.dart
+++ b/risk_eye_mobile_app/lib/features/result/result_page.dart
@@ -1,37 +1,118 @@
 import 'package:flutter/material.dart';
 import '../../widgets/app_bar.dart';
 import '../../widgets/charts/donut.dart';
-import '../../widgets/charts/radar.dart';
-import '../../widgets/charts/bar.dart';
+import '../../services/analytics_service.dart';
+import '../../state/providers.dart';
+import '../history/history_page.dart';
 
-class ResultPage extends StatelessWidget {
+class ResultPage extends StatefulWidget {
   const ResultPage({super.key});
 
   static const String routeName = '/result';
 
   @override
+  State<ResultPage> createState() => _ResultPageState();
+}
+
+class _ResultPageState extends State<ResultPage> {
+  @override
+  void initState() {
+    super.initState();
+    AnalyticsService.logEvent('result_view');
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final result = appState.lastResult;
+    final historyItem = appState.history.isNotEmpty ? appState.history.last : null;
+
+    if (result == null || historyItem == null) {
+      return const Scaffold(
+        appBar: RiskAppBar(title: '评估结果'),
+        body: Center(child: Text('暂无结果')),
+      );
+    }
+
+    Color decisionColor;
+    if (result.score >= 720) {
+      decisionColor = Colors.green;
+    } else if (result.score >= 600) {
+      decisionColor = Colors.orange;
+    } else {
+      decisionColor = Colors.red;
+    }
+
     return Scaffold(
-      appBar: const RiskAppBar(title: '评估结果（已保存）'),
+      appBar: const RiskAppBar(title: '评估结果'),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          children: const [
-            Center(child: DonutScoreChart(score: 720)),
-            SizedBox(height: 16),
-            Text('决策：通过'),
-            SizedBox(height: 16),
-            Text('优势'),
-            Text('• 收入稳定'),
-            Text('• 流水连续'),
-            SizedBox(height: 16),
-            Text('风险'),
-            Text('• 近3月消费波动偏高'),
-            SizedBox(height: 16),
-            RadarChart(),
-            SizedBox(height: 16),
-            BarChart(),
+          children: [
+            Center(child: DonutScoreChart(score: result.score)),
+            const SizedBox(height: 16),
+            Text('决策：${result.decision}', style: TextStyle(color: decisionColor)),
+            Text('等级：${result.grade}'),
+            const SizedBox(height: 4),
+            Text('评估时间：${historyItem.createdAt}'),
+            Text('模型版本：${result.modelVersion}'),
+            const SizedBox(height: 16),
+            if (result.strengths.isNotEmpty) ...[
+              const Text('优势'),
+              for (final s in result.strengths.take(3)) Text('• $s'),
+              const SizedBox(height: 16),
+            ],
+            if (result.risks.isNotEmpty) ...[
+              const Text('风险'),
+              for (final r in result.risks.take(3)) Text('• $r'),
+              const SizedBox(height: 16),
+            ],
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      AnalyticsService.logEvent('export_click');
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('已保存结果')),
+                      );
+                    },
+                    child: const Text('保存结果'),
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {
+                      AnalyticsService.logEvent('trend_click');
+                      Navigator.pushNamed(context, HistoryPage.routeName);
+                    },
+                    child: const Text('查看历史趋势'),
+                  ),
+                ),
+              ],
+            ),
+            if (result.decision == '人工审核') ...[
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  AnalyticsService.logEvent('review_request');
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('已提交人工审核')),
+                  );
+                },
+                child: const Text('提交人工审核'),
+              ),
+            ] else if (result.decision == '失败') ...[
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  AnalyticsService.logEvent('result_retry');
+                  Navigator.pop(context);
+                },
+                child: const Text('重试'),
+              ),
+            ],
           ],
         ),
       ),

--- a/risk_eye_mobile_app/lib/router.dart
+++ b/risk_eye_mobile_app/lib/router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'features/upload/upload_page.dart';
 import 'features/evaluating/evaluating_page.dart';
 import 'features/result/result_page.dart';
+import 'features/history/history_page.dart';
 
 /// Centralized app route generator.
 class AppRouter {
@@ -14,6 +15,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const EvaluatingPage());
       case ResultPage.routeName:
         return MaterialPageRoute(builder: (_) => const ResultPage());
+      case HistoryPage.routeName:
+        return MaterialPageRoute(builder: (_) => const HistoryPage());
       default:
         return null;
     }

--- a/risk_eye_mobile_app/lib/state/app_state.dart
+++ b/risk_eye_mobile_app/lib/state/app_state.dart
@@ -17,6 +17,9 @@ class AppState extends ChangeNotifier {
   List<HistoryItem> _history = [];
   List<HistoryItem> get history => _history;
 
+  ScoreResult? _lastResult;
+  ScoreResult? get lastResult => _lastResult;
+
   Future<void> loadHistory() async {
     _history = await _storage.loadHistory();
     notifyListeners();
@@ -24,6 +27,7 @@ class AppState extends ChangeNotifier {
 
   Future<ScoreResult> startEvaluation() async {
     final result = await _engine.evaluate();
+    _lastResult = result;
     final item = HistoryItem(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       createdAt: DateTime.now(),


### PR DESCRIPTION
## Summary
- store latest evaluation result in AppState for UI access
- show dynamic score, decision, model info, and factors on result page with CTAs and analytics
- wire up history route for navigation

## Testing
- `flutter format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa740ced7c832b982ae13e02d77043